### PR TITLE
FIX: compatibility with werkzeug>1.0.0

### DIFF
--- a/werkzeug_debugger_runserver/management/commands/runserver.py
+++ b/werkzeug_debugger_runserver/management/commands/runserver.py
@@ -151,7 +151,8 @@ class Command(BaseCommand):
             from django.core.handlers.wsgi import WSGIHandler  # noqa
 
         try:
-            from werkzeug import run_simple, DebuggedApplication
+            from werkzeug import run_simple
+            from werkzeug.debug import DebuggedApplication
 
             # Set colored output
             if settings.DEBUG:


### PR DESCRIPTION
Fix this annoying error:

```
CommandError: Werkzeug is required to use runserver_plus.  Please visit http://werkzeug.pocoo.org/ or install via pip. (pip install Werkzeug)
```

Found the solution [here](https://github.com/django-extensions/django-extensions/pull/1477#issue-561321806).